### PR TITLE
Create contentful client with ts validation

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,31 @@
-import type { NextPage } from "next";
+import { createClient } from "contentful";
+import type { InferGetStaticPropsType } from "next";
 import Head from "next/head";
 
-const Home: NextPage = () => {
+export const getStaticProps = async () => {
+  if (
+    !process.env.CONTENTFUL_SPACE_ID ||
+    !process.env.CONTENTFUL_ACCESS_TOKEN
+  ) {
+    throw new Error("Contentful Space Id or Access Token not found");
+  }
+
+  const client = createClient({
+    space: process.env.CONTENTFUL_SPACE_ID,
+    accessToken: process.env.CONTENTFUL_ACCESS_TOKEN,
+  });
+
+  const response = await client.getEntries({ content_type: "recipe" });
+
+  return {
+    props: {
+      recipes: response.items,
+    },
+    revalidate: 60,
+  };
+};
+
+const Home = ({ recipes }: InferGetStaticPropsType<typeof getStaticProps>) => {
   return (
     <div>
       <Head>


### PR DESCRIPTION
Create Contentful Client on getStaticProps function with TypeScript validation on Home page.
Home gets recipes prop which is inferred via `InferGetStaticPropsType<typeof getStaticProps>`